### PR TITLE
掲示板のレスポンシブ対応

### DIFF
--- a/src/Controller/ThreadsController.php
+++ b/src/Controller/ThreadsController.php
@@ -24,10 +24,9 @@ class ThreadsController extends AppController
      */
     public function index()
     {
-        $this->paginate = [
-            'contain' => ['Users','Posts']
-        ];
-        $threads = $this->paginate($this->Threads->find('search', ['search' => $this->request->query]));
+        $threads = $this->paginate($this->Threads->find()->contain(['Posts' => function($q){
+              return $q->order(['modified' => 'DESC']);
+        }]));
         $this->set(compact('threads'));
         $this->set('_serialize', ['threads']);
     }

--- a/src/Template/Element/rankCreate.ctp
+++ b/src/Template/Element/rankCreate.ctp
@@ -1,16 +1,16 @@
 <?php $rCount = 1;?>
-<?php foreach($allTags as $key => $rankTag): ?>
+<?php foreach($threeTag as $key => $rankTag): ?>
   <div class="col-md-4 ranking-list">
     <div class="row">
       <div class="col-xs-6">
-        <div class="rank-<?= $rCount; ?>"></div>
+        <div class="rank-<?= $rankTag['rank']; ?>"></div>
       </div>
       <div class="col-xs-6">
         <div class="w-100">
-          <span class="label label-default label-color-<?= $rCount; ?>"><?= $key ?></span>
+          <span class="label label-default label-color-<?= $rankTag['rank']; ?>"><?= $key ?></span>
         </div>
         <div class="w-100">
-          <i class="glyphicon glyphicon-thumbs-up mar-le-10 gly-color-<?= $rCount; ?>"></i><?= __(':').$rankTag ?>
+          <i class="glyphicon glyphicon-thumbs-up mar-le-10 gly-color-<?= $rankTag['rank']; ?>"></i><?= __(':').$rankTag['count'] ?>
         </div>
       </div>
     </div>

--- a/src/Template/Events/view.ctp
+++ b/src/Template/Events/view.ctp
@@ -43,28 +43,27 @@ $w = date('w', strtotime($event->start));
 	        <hr class="mb0">
 
 	        <div class="fu-list">
+            <div class="alt-table-responsive">
 	            <table class="table table-hover table-striped">
 	                <thead>
 	                <tr>
-	                		<th colspan="2"><?= __('ユーザー名'); ?></th>
-	                    <th><?= $this->Paginator->sort('title', __('ゼミ資料タイトル')); ?></th>
-                      <th class="mi-w-380"><?= $this->Paginator->sort('file', __('資料名')); ?></th>
-                      <th class="w-500"><?= $this->Paginator->sort('url', __('参考URL')); ?></th>
-	                    <th class="b_w150">　</th>
+                      <th class="col-xs-1"><?= __('名前'); ?></th>
+                      <th class="col-xs-2"><?= $this->Paginator->sort('title', __('資料名')); ?></th>
+                      <th class="col-xs-6"><?= $this->Paginator->sort('file', __('資料名')); ?></th>
+                      <th class="col-xs-2 hidden-xs"><?= $this->Paginator->sort('url', __('参考URL')); ?></th>
+                      <th class="col-xs-1">　</th>
 	                </tr>
 	                </thead>
 	                <?php foreach ($attachments as $attachment): ?>
 	                <tr>
 		                <td class="img-50">
+                      <p class="post-nickname"><?= $attachment->user->nickname ?></p>
 	                    <?php if($attachment->user->photo): ?>
 	                            <?= $this->Html->image('/files/Users/photo/'.$attachment->user->photo,['alt' => '写真を設定してください','class' => 'img-50']) ?>
 	                    <?php else: ?>
 	                            <?= $this->Html->image('noimage.png',['class' => 'img-50']) ?>
 	                    <?php endif ?>
 	                    </td>
-                      <td>
-                          <?= $attachment->user->nickname ?>
-                      </td>
 	                    <td class="text-muted">
 	                        <?= $attachment->title; ?>
 													<div class="font-24">
@@ -101,7 +100,7 @@ $w = date('w', strtotime($event->start));
 														<?php endforeach?>
 													</ul>
                       </td>
-                      <td>
+                      <td class="hidden-xs">
                       <?php if($attachment->url !== ''): ?>
                           <?= $this->Html->link($attachment->url) ?>
                       <?php endif ?>
@@ -112,7 +111,8 @@ $w = date('w', strtotime($event->start));
 	                    </td>
 	                </tr>
 	                <?php endforeach ?>
-	            </table>
+              </table>
+            </div>
 	        </div>
 	    </div>
 	</div>

--- a/src/Template/Threads/index.ctp
+++ b/src/Template/Threads/index.ctp
@@ -34,13 +34,12 @@
         </div>
         <div class="col-md-2"></div>
     </div>
-
     <div class="fu-list">
         <table class="table table-hover table-striped">
             <thead>
             <tr>
                 <th><?= $this->Paginator->sort('title', __('タイトル')); ?></th>
-                <th><?= $this->Paginator->sort('modified', __('更新日')); ?></th>
+                <th><?= __('最終更新日'); ?></th>
                 <th class="b_w150">　</th>
             </tr>
             </thead>
@@ -57,7 +56,7 @@
                     <span class="text-muted">(<?= count($thread->posts); ?>)</span>
                 </td>
                 <td>
-                    <?= date('Y-m-d', strtotime($thread['modified'])) ?><?= $week[$w]; ?>
+                    <?= date('Y-m-d', strtotime($thread->posts[0]['modified'])) ?><?= $week[$w]; ?>
                 </td>
                 <td class="tc">
                 <?php if($thread->user_id === $user['id']): ?>

--- a/src/Template/Threads/posts.ctp
+++ b/src/Template/Threads/posts.ctp
@@ -23,13 +23,14 @@
     <?= $this->Form->end() ?>
 </div>
 <div class="fu-list">
+  <div class="alt-table-responsive">
     <table class="table table-hover table-striped">
         <thead>
         <tr>
-            <th colspan="2"><?= __('ユーザー名'); ?></th>
-            <th><?= __('コメント'); ?></th>
-            <th><?= $this->Paginator->sort('modified', __('投稿時間')); ?></th>
-            <th><?= __(""); ?></th>
+            <th class="col-xs-1"><?= __('名前'); ?></th>
+            <th class="col-xs-8"><?= __('コメント'); ?></th>
+            <th class="col-xs-2"><?= $this->Paginator->sort('modified', __('投稿時間')); ?></th>
+            <th class="col-xs-1"><?= __(""); ?></th>
         </tr>
         </thead>
         <?php foreach ($posts as $post): ?>
@@ -41,16 +42,16 @@
             <?php foreach($users as $targetUser): ?>
                 <?php if($targetUser->id === $post->user_id): ?>
                     <td class="img-50">
+                    <p class="post-nickname"><?= $targetUser->nickname ?></p>
                     <?php if($targetUser['photo']): ?>
                             <?= $this->Html->image('/files/Users/photo/'.$targetUser['photo'],['alt' => '写真を設定してください','class' => 'img-50']) ?>
                     <?php else: ?>
                             <?= $this->Html->image('noimage.png',['class' => 'img-50']) ?>
                     <?php endif ?>
                     </td>
-                    <td><?= $targetUser->nickname ?></td>
                 <?php endif ?>
             <?php endforeach ?>
-            <td style="max-width: 400px;">
+            <td>
                 <ul style="list-style: none; padding-left: 0px;">
                     <li class="urlComment"><?= nl2br($post->comment) ?></li>
                     <?php if($post->url !== ''): ?>
@@ -71,5 +72,6 @@
         </tr>
         <?php endforeach ?>
     </table>
+  </div>
 </div>
 <?= $this->Html->script('url2link.js') ?>

--- a/webroot/css/laboratory.css
+++ b/webroot/css/laboratory.css
@@ -317,3 +317,16 @@ ul.rank-right{
 #allCheck {
   margin-right: 5px;
 }
+/*********掲示板レスポンシブ用***********/
+.alt-table-responsive {
+    width: 100%;
+    overflow-y: hidden;
+    overflow-x: auto;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    -webkit-overflow-scrolling: touch;
+  word-break:break-all;
+}
+.post-nickname {
+  margin-bottom: 0;
+}
+/***************************************/


### PR DESCRIPTION
### 概要
- 掲示板のコメント欄がレスポンシブ対応になっていないので、常に、横スクロールが発生しないようにする
- 同率順位の時の表示を変更する
- スレッドの「更新日」はスレッド内のコメントの最新更新時間にするのが適している


### 実装タスク
- [x] #7 
- [x] #48 
- [x] #58 