### PR TITLE
ユーザーの画像保存時にファイルと同様に一意に識別できるようにする

### DIFF
--- a/src/Controller/AdminsController.php
+++ b/src/Controller/AdminsController.php
@@ -44,8 +44,6 @@ class AdminsController extends AppController
             $userName = $this->Auth->user();
             //ファイルの拡張を取得する
             $filePath = pathinfo($this->request->data['photo']['name']);
-            //ユーザーが提出したファイル名を避難させる(画面に表示するカラムとなる)
-            $this->request->data['tmp_file_name'] = $this->request->data['photo']['name'];
             //ファイル名(例):10-admin-2017.docx(id-userName-year.拡張子)
             $this->request->data['photo']['name'] = 1+$lastId['id'].'-user-'.date('Y').'.'.$filePath['extension'];
             $user = $this->Admins->Users->patchEntity($user, $this->request->data);

--- a/src/Controller/AdminsController.php
+++ b/src/Controller/AdminsController.php
@@ -32,14 +32,24 @@ class AdminsController extends AppController
     /**
      * User add method
      * 管理者のみがユーザーを追加できるようにする
-     * 
+     *
      */
     public function userAdd()
     {
         $user = $this->Admins->Users->newEntity();
         if ($this->request->is('post')) {
+            //Userssテーブルの(最後のID + 1)を取得する
+            $lastId = $this->Admins->Users->find()->order(['Users.id' => 'DESC'])->first();
+            //ファイルを提出したユーザー名を取得する
+            $userName = $this->Auth->user();
+            //ファイルの拡張を取得する
+            $filePath = pathinfo($this->request->data['photo']['name']);
+            //ユーザーが提出したファイル名を避難させる(画面に表示するカラムとなる)
+            $this->request->data['tmp_file_name'] = $this->request->data['photo']['name'];
+            //ファイル名(例):10-admin-2017.docx(id-userName-year.拡張子)
+            $this->request->data['photo']['name'] = 1+$lastId['id'].'-user-'.date('Y').'.'.$filePath['extension'];
             $user = $this->Admins->Users->patchEntity($user, $this->request->data);
-            
+
             if ($this->Admins->Users->save($user)) {
                 $this->Flash->success(__('新規ユーザーが登録されました。'));
                 return $this->redirect(['controller' => 'users' ,'action' => 'index']);
@@ -54,7 +64,7 @@ class AdminsController extends AppController
     /**
      * is Authorized method
      * 管理者(role=admin)のみがアクセスできるようにする
-     * 
+     *
      */
     public function isAuthorized($user)
     {

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -64,6 +64,9 @@ class UsersController extends AppController
                 $this->Flash->error(__('パスワードが間違ってます。'));
                 return $this->redirect(['action' => 'edit', $user->id]);
             }
+            $userName = $this->Auth->user();
+            $filePath = pathinfo($this->request->data['photo']['name']);
+            $this->request->data['photo']['name'] = $user['id'].'-user-'.date('Y').'.'.$filePath['extension'];
             $user = $this->Users->patchEntity($user, $this->request->data);
             if ($this->Users->save($user)) {
                 $this->Flash->success(__('ユーザー情報を更新しました。'));


### PR DESCRIPTION
### 概要
ユーザーの画像を一意に識別できるようにして画像の名前で衝突しないようにする

### 実装タスク
- [x] #32 