### PR TITLE
管理者以外のユーザが誤削除しないように削除できる場所を1つだけにする

### DIFF
--- a/src/Template/Users/edit.ctp
+++ b/src/Template/Users/edit.ctp
@@ -5,12 +5,6 @@
 ?>
 <nav class="large-3 medium-4 columns" id="actions-sidebar">
     <ul class="side-nav">
-        <li><?= $this->Form->postLink(
-                __('削除'),
-                ['action' => 'delete', $user->id],
-                ['confirm' => __('本当に削除してよろしいですか # {0}?', $user->id)]
-            )
-        ?></li>
         <li><?= $this->Html->link(__('ユーザー一覧'), ['action' => 'index']) ?></li>
     </ul>
 </nav>


### PR DESCRIPTION
### 概要
ユーザー情報を修正するときに「削除」の文字がなんとなくあるので、間違って押してしまいそう
とりあえず、削除はユーザー一覧画面からのみできるようにする

### 実装タスク
- [x] ユーザー編集画面の「削除」の項目を削除する