### PR TITLE
ところどころ気になる文言の修正を行う

### DIFF
--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -55,11 +55,11 @@ class TagsController extends AppController
         if ($this->request->is('post')) {
             $tag = $this->Tags->patchEntity($tag, $this->request->data);
             if ($this->Tags->save($tag)) {
-                $this->Flash->success(__('The tag has been saved.'));
+                $this->Flash->success(__('タグが保存されました'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The tag could not be saved. Please, try again.'));
+            $this->Flash->error(__('タグを追加できませんでした'));
         }
         $users = $this->Tags->Users->find('list', ['limit' => 200]);
         $attachments = $this->Tags->Attachments->find('list', ['limit' => 200]);
@@ -82,11 +82,11 @@ class TagsController extends AppController
         if ($this->request->is(['patch', 'post', 'put'])) {
             $tag = $this->Tags->patchEntity($tag, $this->request->data);
             if ($this->Tags->save($tag)) {
-                $this->Flash->success(__('The tag has been saved.'));
+                $this->Flash->success(__('タグを修正しました'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The tag could not be saved. Please, try again.'));
+            $this->Flash->error(__('タグを修正できませんでした'));
         }
         $users = $this->Tags->Users->find('list', ['limit' => 200]);
         $attachments = $this->Tags->Attachments->find('list', ['limit' => 200]);
@@ -106,9 +106,9 @@ class TagsController extends AppController
         $this->request->allowMethod(['post', 'delete']);
         $tag = $this->Tags->get($id);
         if ($this->Tags->delete($tag)) {
-            $this->Flash->success(__('The tag has been deleted.'));
+            $this->Flash->success(__('削除しました'));
         } else {
-            $this->Flash->error(__('The tag could not be deleted. Please, try again.'));
+            $this->Flash->error(__('削除できませんでした'));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Template/Events/view.ctp
+++ b/src/Template/Events/view.ctp
@@ -48,7 +48,7 @@ $w = date('w', strtotime($event->start));
 	                <thead>
 	                <tr>
                       <th class="col-xs-1"><?= __('名前'); ?></th>
-                      <th class="col-xs-2"><?= $this->Paginator->sort('title', __('資料名')); ?></th>
+                      <th class="col-xs-2"><?= $this->Paginator->sort('title', __('タイトル')); ?></th>
                       <th class="col-xs-6"><?= $this->Paginator->sort('file', __('資料名')); ?></th>
                       <th class="col-xs-2 hidden-xs"><?= $this->Paginator->sort('url', __('参考URL')); ?></th>
                       <th class="col-xs-1">　</th>

--- a/src/Template/Tags/index.ctp
+++ b/src/Template/Tags/index.ctp
@@ -9,13 +9,13 @@
     </ul>
 </nav>
 <div class="tags index large-9 medium-8 columns content">
-    <h3><?= __('Tags') ?></h3>
+    <h3><?= __('タグ一覧') ?></h3>
     <table cellpadding="0" cellspacing="0">
         <thead>
             <tr>
                 <th scope="col"><?= $this->Paginator->sort('id') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('category') ?></th>
-                <th scope="col" class="actions"><?= __('Actions') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('category', ['labels' => 'カテゴリー']) ?></th>
+                <th scope="col" class="actions"><?= __('操作') ?></th>
             </tr>
         </thead>
         <tbody>
@@ -24,8 +24,8 @@
                 <td><?= $this->Number->format($tag->id) ?></td>
                 <td><?= $tag->category ?></td>
                 <td class="actions">
-                    <?= $this->Html->link(__('Edit'), ['action' => 'edit', $tag->id]) ?>
-                    <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $tag->id], ['confirm' => __('削除してもいいですか?', $tag->id)]) ?>
+                    <?= $this->Html->link(__('修正'), ['action' => 'edit', $tag->id]) ?>
+                    <?= $this->Form->postLink(__('削除'), ['action' => 'delete', $tag->id], ['confirm' => __('削除してもいいですか?', $tag->id)]) ?>
                 </td>
             </tr>
             <?php endforeach; ?>
@@ -33,11 +33,11 @@
     </table>
     <div class="paginator">
         <ul class="pagination">
-            <?= $this->Paginator->first('<< ' . __('first')) ?>
-            <?= $this->Paginator->prev('< ' . __('previous')) ?>
+            <?= $this->Paginator->first('<< ' . __('初め')) ?>
+            <?= $this->Paginator->prev('< ' . __('前')) ?>
             <?= $this->Paginator->numbers() ?>
-            <?= $this->Paginator->next(__('next') . ' >') ?>
-            <?= $this->Paginator->last(__('last') . ' >>') ?>
+            <?= $this->Paginator->next(__('次') . ' >') ?>
+            <?= $this->Paginator->last(__('最後') . ' >>') ?>
         </ul>
         <p><?= $this->Paginator->counter(['format' => __('{{pages}}ページ中の{{page}}ページ目, 全部で{{count}}件中の{{current}}件分を表示')]) ?></p>
     </div>

--- a/src/Template/Threads/posts.ctp
+++ b/src/Template/Threads/posts.ctp
@@ -18,7 +18,7 @@
         </div>
     </fieldset>
     <div class="login-button text-right">
-      <?= $this->Form->button(__('新規登録'),['class' => 'btn btn-raised btn-success glyphicon glyphicon-plus']) ?>
+      <?= $this->Form->button(__('コメントする'),['class' => 'btn btn-raised btn-success']) ?>
     </div>
     <?= $this->Form->end() ?>
 </div>

--- a/src/Template/Users/evaluation.ctp
+++ b/src/Template/Users/evaluation.ctp
@@ -19,13 +19,20 @@
   </div>
   <div class="row">
     <div class="col-sm-5">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3><?= __($user['nickname'].'さんへの総いいね数') ?></h3>
+        </div>
+      </div>
       <div class="row flexiblebox">
-        <blockquote class="sub-title"><?= __('総いいね数') ?></blockquote>
-        <div class="col-xs-6">
+        <div class="col-xs-5 text-right">
           <span class="font-70"><?= $iineEval['iine'] ?></span>
         </div>
-        <div class="col-xs-6">
-          <span class="font-100"><i class="glyphicon glyphicon-thumbs-up ajaxFav mar-le-10"></i></span>
+        <div class="col-xs-2">
+          <span class="font-70"><?= __("×") ?></span>
+        </div>
+        <div class="col-xs-5">
+          <span class="font-100 favChecked"><i class="glyphicon glyphicon-thumbs-up ajaxFav mar-le-10"></i></span>
         </div>
       </div>
     </div>

--- a/src/Template/Users/index.ctp
+++ b/src/Template/Users/index.ctp
@@ -8,7 +8,7 @@
         <div class="tools">
             <div class="row">
                 <div class="col-xs-4">
-                  <?= $this->Html->link(__('ユーザー新規作成'),['controller' => 'admins' ,'action' => 'user_add'], ['class' => 'glyphicon glyphicon-plus btn btn-default']) ?>
+                  <?= $this->Html->link(__('ユーザー新規作成'),['controller' => 'admins' ,'action' => 'user_add'], ['class' => 'btn btn-default']) ?>
                 </div>
                 <div class="col-xs-8">
                 </div>

--- a/webroot/css/laboratory.css
+++ b/webroot/css/laboratory.css
@@ -317,6 +317,11 @@ ul.rank-right{
 #allCheck {
   margin-right: 5px;
 }
+/*************マイページ用***************/
+.text-right {
+  text-align: right;
+}
+/****************************************/
 /*********掲示板レスポンシブ用***********/
 .alt-table-responsive {
     width: 100%;


### PR DESCRIPTION
### 概要
掲示板のコメント送信時に「新規登録」とか、なんかダサい気がするから修正

### 実装タスク
- [x] 掲示板「新規登録」=> 「コメントする」　＋　gluphiconは削除
- [x]  タグ作成成功時の言葉が英語なので日本語に直す
- [x]  ゼミ詳細画面の「資料名」=>「タイトル」
- [x]  ユーザー一覧「ユーザー新規作成」のglyphicon削除
- [x] マイページ「総いいね数」=>「みんなからあなたへの総いいね数」