### PR TITLE
markdown記述時に遅くなることへの対処

### DIFF
--- a/webroot/js/markdown/editor.js
+++ b/webroot/js/markdown/editor.js
@@ -8,7 +8,7 @@ $(function() {
         var src = $(this).val();
         var html = marked(src);
         $('#result').html(html);
-        $('pre code').each(function(i, block) {
+        $('#result pre code').each(function(i, block) {
             hljs.highlightBlock(block);
         });
     });


### PR DESCRIPTION
## 概要
markdownを記述していると処理が遅くなることがあった
おそらく入力されるたびにページ全体の`pre code`に対してhighlightする処理が入っていたためだと思われる

## 実装タスク
- [x] #110 